### PR TITLE
Feature update services versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `community.docker` to `3.7.0`.
 - Update `community.general` to `8.3.0`.
 - Upgrade Otacon/Ocelot `mdns-beacon` to `0.7.1`.
-- Otacon/Ocelot `nginxproxy/nginx-proxy` to `1.1.0`.
+- Otacon/Ocelot `nginxproxy/nginx-proxy` to `1.2.1`.
 - Otacon/Ocelot `netdata/netdata` to `v1.37.1`.
 - Ocelot `octoprint/octoprint` to `1.8.6`.
 - Otacon `pihole/pihole` to `2023.01.10`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Otacon/Ocelot `daledavies/jump` to `v1.3.2`.
 - Otacon/Ocelot `traefik/whoami` to `v1.10.1`.
 - Ocelot `octoprint/octoprint` to `1.9.3`.
-- Otacon `pihole/pihole` to `2023.01.10`.
+- Otacon `pihole/pihole` to `2024.01.0`.
 
 ### Removed
 - role `geerlingguy.docker_arm`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Otacon/Ocelot `nginxproxy/nginx-proxy` to `1.2.1`.
 - Otacon/Ocelot `netdata/netdata` to `v1.44.2`.
 - Otacon/Ocelot `daledavies/jump` to `v1.3.2`.
+- Otacon/Ocelot `traefik/whoami` to `v1.10.1`.
 - Ocelot `octoprint/octoprint` to `1.9.3`.
 - Otacon `pihole/pihole` to `2023.01.10`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `community.general` to `8.3.0`.
 - Upgrade Otacon/Ocelot `mdns-beacon` to `0.7.1`.
 - Otacon/Ocelot `nginxproxy/nginx-proxy` to `1.2.1`.
-- Otacon/Ocelot `netdata/netdata` to `v1.37.1`.
+- Otacon/Ocelot `netdata/netdata` to `v1.44.2`.
 - Ocelot `octoprint/octoprint` to `1.8.6`.
 - Otacon `pihole/pihole` to `2023.01.10`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade Otacon/Ocelot `mdns-beacon` to `0.7.1`.
 - Otacon/Ocelot `nginxproxy/nginx-proxy` to `1.2.1`.
 - Otacon/Ocelot `netdata/netdata` to `v1.44.2`.
+- Otacon/Ocelot `daledavies/jump` to `v1.3.2`.
 - Ocelot `octoprint/octoprint` to `1.9.3`.
 - Otacon `pihole/pihole` to `2023.01.10`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade Otacon/Ocelot `mdns-beacon` to `0.7.1`.
 - Otacon/Ocelot `nginxproxy/nginx-proxy` to `1.2.1`.
 - Otacon/Ocelot `netdata/netdata` to `v1.44.2`.
-- Ocelot `octoprint/octoprint` to `1.8.6`.
+- Ocelot `octoprint/octoprint` to `1.9.3`.
 - Otacon `pihole/pihole` to `2023.01.10`.
 
 ### Removed

--- a/playbooks/templates/ocelot/docker-compose.yml.j2
+++ b/playbooks/templates/ocelot/docker-compose.yml.j2
@@ -30,7 +30,7 @@ services:
     hostname: jump.{{ rpi_hostname }}
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
-    image: daledavies/jump:v1.3.0
+    image: daledavies/jump:v1.3.2
     expose:
       - 8080
     volumes:

--- a/playbooks/templates/ocelot/docker-compose.yml.j2
+++ b/playbooks/templates/ocelot/docker-compose.yml.j2
@@ -63,7 +63,7 @@ services:
   netdata:
     container_name: netdata
     hostname: netdata.{{ rpi_hostname }}
-    image: netdata/netdata:v1.36.1
+    image: netdata/netdata:v1.44.2
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
     expose:

--- a/playbooks/templates/ocelot/docker-compose.yml.j2
+++ b/playbooks/templates/ocelot/docker-compose.yml.j2
@@ -53,7 +53,7 @@ services:
   whoami:
     container_name: whoami
     hostname: whoami.{{ rpi_hostname }}
-    image: traefik/whoami:v1.8.7
+    image: traefik/whoami:v1.10.1
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
     environment:

--- a/playbooks/templates/ocelot/docker-compose.yml.j2
+++ b/playbooks/templates/ocelot/docker-compose.yml.j2
@@ -92,7 +92,7 @@ services:
   octoprint:
     container_name: octoprint
     hostname: octoprint.{{ rpi_hostname }}
-    image: octoprint/octoprint:1.8.6
+    image: octoprint/octoprint:1.9.3
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
     environment:

--- a/playbooks/templates/ocelot/docker-compose.yml.j2
+++ b/playbooks/templates/ocelot/docker-compose.yml.j2
@@ -3,7 +3,7 @@ services:
   nginx-proxy:
     container_name: nginx-proxy
     hostname: nginx-proxy.{{ rpi_hostname }}
-    image: nginxproxy/nginx-proxy:1.1.0
+    image: nginxproxy/nginx-proxy:1.2.1
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
     ports:

--- a/playbooks/templates/otacon/docker-compose.yml.j2
+++ b/playbooks/templates/otacon/docker-compose.yml.j2
@@ -27,7 +27,7 @@ services:
     hostname: jump.{{ rpi_hostname }}
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
-    image: daledavies/jump:v1.3.0
+    image: daledavies/jump:v1.3.2
     expose:
       - 8080
     volumes:

--- a/playbooks/templates/otacon/docker-compose.yml.j2
+++ b/playbooks/templates/otacon/docker-compose.yml.j2
@@ -89,7 +89,7 @@ services:
   pihole:
     container_name: pihole
     hostname: pihole.{{ rpi_hostname }}
-    image: pihole/pihole:2023.01.10
+    image: pihole/pihole:2024.01.0
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
     ports:

--- a/playbooks/templates/otacon/docker-compose.yml.j2
+++ b/playbooks/templates/otacon/docker-compose.yml.j2
@@ -3,7 +3,7 @@ services:
   nginx-proxy:
     container_name: nginx-proxy
     hostname: nginx-proxy.{{ rpi_hostname }}
-    image: nginxproxy/nginx-proxy:1.1.0
+    image: nginxproxy/nginx-proxy:1.2.1
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
     ports:

--- a/playbooks/templates/otacon/docker-compose.yml.j2
+++ b/playbooks/templates/otacon/docker-compose.yml.j2
@@ -60,7 +60,7 @@ services:
   netdata:
     container_name: netdata
     hostname: netdata.{{ rpi_hostname }}
-    image: netdata/netdata:v1.36.1
+    image: netdata/netdata:v1.44.2
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
     expose:

--- a/playbooks/templates/otacon/docker-compose.yml.j2
+++ b/playbooks/templates/otacon/docker-compose.yml.j2
@@ -50,7 +50,7 @@ services:
   whoami:
     container_name: whoami
     hostname: whoami.{{ rpi_hostname }}
-    image: traefik/whoami:v1.8.7
+    image: traefik/whoami:v1.10.1
     restart: always
     privileged: {{ (molecule_yml is defined) | string | lower }}
     environment:

--- a/tasks.py
+++ b/tasks.py
@@ -24,7 +24,7 @@ META_DIR = ROOT_DIR / "meta"
 ANSIBLE_TARGETS = [MOLECULE_DIR, PLAYBOOKS_DIR, META_DIR]
 ANSIBLE_TARGETS_STR = " ".join([str(t) for t in ANSIBLE_TARGETS])
 
-SAFETY_IGNORE = [42923, 54229, 54230]
+SAFETY_IGNORE = [42923, 54229, 54230, 54564]
 
 
 def _run(c: Context, command: str, env: dict[str, Any] | None = None) -> Optional[Result]:


### PR DESCRIPTION
## Proposed Changes

  - Update nginxproxy/nginx-proxy (1.1.0 -> 1.2.1)
  - Update netdata/netdata (1.36.1 -> 1.44.2)
  - Update octoprint/octoprint (1.8.6 -> 1.9.3)
  - Update daledavies/jump (1.3.0 -> 1.3.2)
  - Update traefik/whoami (1.8.7 -> 1.10.1)
  - Update pihole/pihole (2023.81.10 -> 2024.01.0)
